### PR TITLE
[Chore] Add systemd unit restart policy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -160,9 +160,15 @@
             wantedBy = [ "multi-user.target" ];
             after = [ "network.target" ];
 
+            startLimitBurst = mkDefault 5;
+            startLimitIntervalSec = mkDefault 300;
+
             serviceConfig = {
               User = cfg.user;
               Group = cfg.group;
+
+              Restart = mkDefault "on-failure";
+              RestartSec = mkDefault 10;
 
               CapabilityBoundingSet = "CAP_NET_ADMIN";
               AmbientCapabilities = "CAP_NET_ADMIN";


### PR DESCRIPTION
Problem: By default, systemd services generated from the NixOS system configuration don't attempt to restart on failure since Restart=no. However, in some cases, running processes can fail for unclear reasons, and the simplest way to bring the failed service back to life is to restart it. Instead, currently, the service will fail and trigger an alert without attempting to restart.

Solution: Add default values for startLimitBurst, startLimitIntervalSec, Restart, and RestartSec.

to:
cc: @subspacecommunity/subspace-maintainers
related to:
resolves:

## Background

Reason for the change

### Changes

* Summary of changes
* ...


## Testing

Steps for how this change was tested and verified


