### PR TITLE
[OPS-1548] Use upstream wg-bond

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648199409,
+        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1644229661,
@@ -29,10 +45,44 @@
         "type": "indirect"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1644420267,
+        "narHash": "sha256-rFJuctggkjM412OC6OGPdXogFp7czGDW05ueWqpJbj8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "98bb5b77c8c6666824a4c13d23befa1e07210ef1",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "wg-bond": "wg-bond"
+      }
+    },
+    "wg-bond": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1702302857,
+        "narHash": "sha256-4F73ljT+EptSGg5at4ITbSlG4zYy07jOe0Yrxp88xtw=",
+        "owner": "cab404",
+        "repo": "wg-bond",
+        "rev": "a5884e451e4cec38f8c0a7e25d79a66926517274",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cab404",
+        "repo": "wg-bond",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,12 @@
 {
   description = "A fork of the simple WireGuard VPN server GUI community maintained ";
 
-  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    wg-bond.url = "github:cab404/wg-bond";
+  };
 
-  outputs = { self, nixpkgs, flake-utils }: (flake-utils.lib.eachDefaultSystem (system:
+  outputs = { self, nixpkgs, flake-utils, wg-bond }: (flake-utils.lib.eachDefaultSystem (system:
     let
       pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; };
     in
@@ -14,7 +17,7 @@
       defaultPackage = self.packages.${system}.subspace;
 
       devShell = pkgs.mkShell {
-        buildInputs = with pkgs; [ self.packages.${system}.wireguard-tools wg-bond go go-bindata ];
+        buildInputs = with pkgs; [ self.packages.${system}.wireguard-tools wg-bond.defaultPackage.${system} go go-bindata ];
       };
     })) // {
     overlay = final: prev: {
@@ -223,7 +226,7 @@
               WorkingDirectory = "${cfg.package}/libexec";
             };
 
-            path = with pkgs; [ wg-bond self.packages.${system}.wireguard-tools iptables bash gawk ];
+            path = with pkgs; [ wg-bond.defaultPackage.${system} self.packages.${system}.wireguard-tools iptables bash gawk ];
 
             preStart = ''
               if [[ ! -f ${cfg.dataDir}/wireguard/wg-bond.json ]]; then


### PR DESCRIPTION
Problem: wg-bond was removed from recent nixpkgs.

Solution: Use wg-bond from cab404/wg-bond.