### PR TITLE
[OPS-1548] Pin compatible wg-bond version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1648199409,
-        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1644229661,
@@ -47,16 +31,18 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1644420267,
-        "narHash": "sha256-rFJuctggkjM412OC6OGPdXogFp7czGDW05ueWqpJbj8=",
-        "owner": "nixos",
+        "lastModified": 1593718460,
+        "narHash": "sha256-uuuZjY0i6hJx+wlkAkGvIiBsiRaUsGpl5aN9EDu2Dv0=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "98bb5b77c8c6666824a4c13d23befa1e07210ef1",
+        "rev": "3b4df94aeb6e215085d08e3d5b0edc1313b9f584",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
@@ -66,21 +52,37 @@
         "wg-bond": "wg-bond"
       }
     },
+    "utils": {
+      "locked": {
+        "lastModified": 1593533949,
+        "narHash": "sha256-j5OH1uR8Mu/NqYH44+gnPln0eoGNNahxl0qNSYNi0Og=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "400fa6d9af95481440d8d69a6b49de5901936730",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "wg-bond": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
       },
       "locked": {
-        "lastModified": 1702302857,
-        "narHash": "sha256-4F73ljT+EptSGg5at4ITbSlG4zYy07jOe0Yrxp88xtw=",
+        "lastModified": 1596763862,
+        "narHash": "sha256-HtBxB6J1r2+FcNk56W39Wlbdml9ha6zZx2em4buqYBI=",
         "owner": "cab404",
         "repo": "wg-bond",
-        "rev": "a5884e451e4cec38f8c0a7e25d79a66926517274",
+        "rev": "cbea75726e05932e51bbc531675ee015ef1c9e62",
         "type": "github"
       },
       "original": {
         "owner": "cab404",
+        "ref": "v0.2.0",
         "repo": "wg-bond",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,9 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    wg-bond.url = "github:cab404/wg-bond";
+
+    # Don't update this this input, as newer versions of wg-bond are no longer compatible with subspace
+    wg-bond.url = "github:cab404/wg-bond/v0.2.0";
   };
 
   outputs = { self, nixpkgs, flake-utils, wg-bond }: (flake-utils.lib.eachDefaultSystem (system:
@@ -13,11 +15,24 @@
     {
       packages.subspace = pkgs.subspace;
       packages.wireguard-tools = pkgs.wireguard-tools;
+      packages.wg-bond = with pkgs; rustPlatform.buildRustPackage {
+        pname = "wg-bond";
+        version = "0.2.0";
+
+        src = wg-bond;
+
+        cargoHash = "sha256-Itw3fnKfUW+67KKB2Y7tutGBTm3E8mGNhBL4MOGEn9o=";
+
+        nativeBuildInputs = [ makeWrapper ];
+        postInstall = ''
+          wrapProgram $out/bin/wg-bond --set PATH ${lib.makeBinPath [ wireguard-tools ]}
+        '';
+      };
 
       defaultPackage = self.packages.${system}.subspace;
 
       devShell = pkgs.mkShell {
-        buildInputs = with pkgs; [ self.packages.${system}.wireguard-tools wg-bond.defaultPackage.${system} go go-bindata ];
+        buildInputs = with pkgs; [ self.packages.${system}.wireguard-tools self.packages.${system}.wg-bond go go-bindata ];
       };
     })) // {
     overlay = final: prev: {
@@ -226,7 +241,7 @@
               WorkingDirectory = "${cfg.package}/libexec";
             };
 
-            path = with pkgs; [ wg-bond.defaultPackage.${system} self.packages.${system}.wireguard-tools iptables bash gawk ];
+            path = with pkgs; [ self.packages.${system}.wg-bond self.packages.${system}.wireguard-tools iptables bash gawk ];
 
             preStart = ''
               if [[ ! -f ${cfg.dataDir}/wireguard/wg-bond.json ]]; then


### PR DESCRIPTION
Problem: In last commit wg-bond was updated to latest upstream, which is no lonegr compatible with subspace. See
https://github.com/subspacecommunity/subspace/pull/222#issuecomment-3676753259

Solution: Pin wg-bond to v0.2.0, which was used until it was removed from nixpkgs.



